### PR TITLE
Revert previous commit that introduced bug in recognizing #endif directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # The Variational Parser
 
-https://github.com/RikkiGibson/variational-compiler
-
-The Variational Parser is an extension of source code which supports variational declarations, statements, and expressions, similar to C preprocessor directives. The planned usage of this parser is to power an Atom editor package which will help users write and edit variational programs. We've pulled in **Megaparsec** to generate a parser and **Aeson** for communication between the Atom front-end and this compiler. We're using **Stack** as a build system, adhering roughly to the standard format for Haskell packages.
+The Variational Parser is an extension of source code which supports variational
+declarations, statements, and expressions, similar to C preprocessor directives.
+The planned usage of this parser is to power an Atom editor package which will
+help users write and edit variational programs. We've pulled in **Megaparsec**
+to generate a parser and **Aeson** for communication between the Atom front-end
+and this compiler. We're using **Stack** as a build system, adhering roughly to
+the standard format for Haskell packages.
 
 See the project report for more information about the design and capabilities of this package.
 
-## How to run it
+## How to install
 You will want to have stack installed to build this package.
 
 ```bash
@@ -16,10 +20,14 @@ cd variational-compiler
 # system package managers (i.e., brew)
 stack setup # don't be alarmed if this takes a few minutes
 stack build
+```
 
+## Example commands
+
+```bash
 # Some example actions you can run:
 # Parse a file with the compiler
-stack exec variational-parser < testfiles/hello.vjava | aeson-pretty
+stack exec variational-parser < testfiles/hello.vjava | stack exec aeson-pretty
 # Reduce an AST
-stack exec variational-view < testfiles/view_input.json | aeson-pretty
+stack exec variational-view < testfiles/view_input.json | stack exec aeson-pretty
 ```

--- a/src/VariationalCompiler/Parser.hs
+++ b/src/VariationalCompiler/Parser.hs
@@ -27,11 +27,9 @@ choiceSegment =
      ck <- choiceKind
      spaceChar
      name <- many alphaNumChar
-     n2 <- newline
      r1 <- region
      r2 <- elseBranch
-     n2 <- newline
-     string "\n#endif" <?> "string \"\\n#endif\" in choiceSegment"
+     string "#endif" <?> "string \"#endif\" in choiceSegment"
      end <- getLineCol
      return (ChoiceSeg $ Choice name ck r1 r2 (Span start end))
   <?> "Choice node"
@@ -39,17 +37,17 @@ choiceSegment =
 choiceKind :: Parser ChoiceKind
 choiceKind =
   try (
-    do string "\n#ifdef" <?> "string \"\\n#ifdef\" in choiceKind"
+    do string "#ifdef" <?> "string \"#ifdef\" in choiceKind"
        return Positive
   ) <|> (
-    do string "\n#ifndef" <?> "string \"\\n#ifndef\" in choiceKind"
+    do string "#ifndef" <?> "string \"#ifndef\" in choiceKind"
        return Contrapositive
   )
 
 elseBranch :: Parser Region
 elseBranch =
   try (
-    do string "\n#else"
+    do string "#else"
        region
   ) <|> (
     do start <- getLineCol
@@ -63,10 +61,10 @@ textSegment = do
   s <- someTill anyChar
     (lookAhead
       (choice
-        [void (string "\n#ifdef" <?> "string \"\\n#ifdef\" in textSegment")
-        , void (string "\n#ifndef" <?> "string \"\\n#ifndef\" in textSegment")
-        , void (string "\n#else" <?> "string \"\\n#else\" in textSegment")
-        , void (string "\n#endif" <?> "string \"\\n#endif\" in textSegment")
+        [void (string "#ifdef" <?> "string \"#ifdef\" in textSegment")
+        , void (string "#ifndef" <?> "string \"#ifndef\" in textSegment")
+        , void (string "#else" <?> "string \"#else\" in textSegment")
+        , void (string "#endif" <?> "string \"#endif\" in textSegment")
         , eof]))
   end <- getLineCol
   return (ContentSeg $ Content s (Span start end))
@@ -82,8 +80,8 @@ region = do
   segs <- manyTill segment
     (lookAhead
       (choice
-        [void (string "\n#else" <?> "string \"\\n#else\" in region")
-        , void (string "\n#endif" <?> "string \"\\n#endif\" in region")
+        [void (string "#else" <?> "string \"#else\" in region")
+        , void (string "#endif" <?> "string \"#endif\" in region")
         , eof]))
   end <- getLineCol
   return (Region segs (Span start end))

--- a/variational-editor-backend.cabal
+++ b/variational-editor-backend.cabal
@@ -1,7 +1,7 @@
-name:                variational-compiler
+name:                variational-editor-backend
 version:             0.1.0.0
 synopsis:            Compiler for text files with variational constructs
-homepage:            https://github.com/rikkigibson/variational-compiler
+homepage:            https://github.com/lambda-land/variational-editor-backend
 license:             MIT
 author:              Rikki Gibson and Cody Ray Hoeft
 maintainer:          rikkigibson@gmail.com
@@ -11,13 +11,18 @@ cabal-version:       >= 1.24
 
 source-repository head
   type:     git
-  location: https://github.com/rikkigibson/variational-compiler
+  location: https://github.com/lambda-land/variational-editor-backend
   branch:   master
 
 executable variational-parser
   hs-source-dirs:      src
   main-is:             Parser.hs
   default-language:    Haskell2010
+  other-modules:
+        VariationalCompiler.Entities
+        VariationalCompiler.Json
+        VariationalCompiler.Parser
+
   build-depends:
     base,
     aeson,


### PR DESCRIPTION
The previous commit attempted to remove extraneous newlines while parsing directives, but this causes an error being communicated in the json output.

Also updated repository information in config files to point to this repository instead of original.